### PR TITLE
Silence "go build" warnings

### DIFF
--- a/utp_internal.h
+++ b/utp_internal.h
@@ -76,7 +76,7 @@ struct UTPSocketKey {
 	uint32 recv_id;		 // "conn_seed", "conn_id"
 
 	UTPSocketKey(const PackedSockAddr& _addr, uint32 _recv_id) {
-		memset(this, 0, sizeof(*this));
+		memset((void*)this, 0, sizeof(*this));
 		addr = _addr;
 		recv_id = _recv_id;
 	}


### PR DESCRIPTION
Running `go build` results in the following message:

```bash
$ go build
# github.com/anacrolix/go-libutp
In file included from utp_api.cpp:26:
utp_internal.h: In constructor ‘UTPSocketKey::UTPSocketKey(const PackedSockAddr&, uint32)’:
utp_internal.h:79:32: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct UTPSocketKey’; use assignment instead [-Wclass-memaccess]
   79 |   memset(this, 0, sizeof(*this));
      |                                ^
utp_internal.h:74:8: note: ‘struct UTPSocketKey’ declared here
   74 | struct UTPSocketKey {
      |        ^~~~~~~~~~~~
# github.com/anacrolix/go-libutp
In file included from utp_callbacks.h:27,
                 from utp_callbacks.cpp:25:
utp_internal.h: In constructor ‘UTPSocketKey::UTPSocketKey(const PackedSockAddr&, uint32)’:
utp_internal.h:79:32: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct UTPSocketKey’; use assignment instead [-Wclass-memaccess]
   79 |   memset(this, 0, sizeof(*this));
      |                                ^
utp_internal.h:74:8: note: ‘struct UTPSocketKey’ declared here
   74 | struct UTPSocketKey {
      |        ^~~~~~~~~~~~
# github.com/anacrolix/go-libutp
In file included from utp_internal.cpp:34:
utp_internal.h: In constructor ‘UTPSocketKey::UTPSocketKey(const PackedSockAddr&, uint32)’:
utp_internal.h:79:32: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct UTPSocketKey’; use assignment instead [-Wclass-memaccess]
   79 |   memset(this, 0, sizeof(*this));
      |                                ^
utp_internal.h:74:8: note: ‘struct UTPSocketKey’ declared here
   74 | struct UTPSocketKey {
      |        ^~~~~~~~~~~~
```

Go version:
```bash
$ go version
go version go1.12.7 linux/amd64
```

I found the solution from intel's TBB repository: https://github.com/intel/tbb/issues/54
Seems it's safe to just cast to `void*`.