### PR TITLE
add NewSocketWithConn to construct socket using a custom net.PacketConn

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -113,6 +113,10 @@ func NewSocket(network, addr string, opts ...NewSocketOpt) (*Socket, error) {
 		return nil, err
 	}
 
+	return NewSocketWithConn(pc, opts...)
+}
+
+func NewSocketWithConn(pc net.PacketConn, opts ...NewSocketOpt) (*Socket, error) {
 	s := &Socket{
 		pc:          pc,
 		backlog:     make(chan *Conn, 5),


### PR DESCRIPTION
Adds a way to create a socket from a user provided PacketConn to support custom transports