### PR TITLE
bool, true and false are keywords in a modern C

### DIFF
--- a/utp_types.h
+++ b/utp_types.h
@@ -117,7 +117,11 @@ typedef const char * cstr;
 typedef char * str;
 
 #ifndef __cplusplus
+#if defined __STDC_VERSION__ && __STDC_VERSION__ > 201710L
+/* bool, true and false are keywords.  */
+#else
 typedef uint8 bool;
+#endif
 #endif
 
 #endif //__UTP_TYPES_H__


### PR DESCRIPTION
This patch prevents the following Erigon's build failure:

```
In file included from ./utp.h:35,
                 from ../../go/pkg/mod/github.com/anacrolix/go-libutp@v1.3.1/callbacks.go:4:
./utp_types.h:120:15: error: two or more data types in declaration specifiers
  120 | typedef uint8 bool;
      |               ^~~~
cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
make: *** [Makefile:119: erigon.cmd] Error 1
error: Bad exit status from /var/tmp/rpm-tmp.g5E1KC (%build)
```