### PR TITLE
feat: add NewSocketFromPacketConn

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -112,7 +112,10 @@ func NewSocket(network, addr string, opts ...NewSocketOpt) (*Socket, error) {
 	if err != nil {
 		return nil, err
 	}
+	return NewSocketFromPacketConn(pc, opts...)
+}
 
+func NewSocketFromPacketConn(pc net.PacketConn, opts ...NewSocketOpt) (*Socket, error) {
 	s := &Socket{
 		pc:          pc,
 		backlog:     make(chan *Conn, 5),


### PR DESCRIPTION
Adds `NewSocketFromPacketConn` to dispatch uTP over a caller-provided `net.PacketConn`. `NewSocket` now delegates to it, so behaviour is unchanged.