### PR TITLE
Port tests from frankban/quicktest and testify to go-quicktest/qt

### DIFF
--- a/accept_write_test.go
+++ b/accept_write_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
+	"github.com/go-quicktest/qt"
 )
 
 // gatedPacketConn only lets packets be received when a token is available. It
@@ -28,18 +28,18 @@ func (me gatedPacketConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 // connection has to wake them up.
 func TestWriteOnAcceptedConnBeforeEstablished(t *testing.T) {
 	dialerPc, err := listenPacket("inproc", "")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	acceptorPc, err := listenPacket("inproc", "")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	// Only the initiating SYN gets through until we release the gate.
 	tokens := make(chan struct{}, 1)
 	tokens <- struct{}{}
 
 	dialer, err := NewSocketFromPacketConn(dialerPc)
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer dialer.Close()
 	acceptor, err := NewSocketFromPacketConn(gatedPacketConn{acceptorPc, tokens})
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer acceptor.Close()
 
 	dialed := make(chan net.Conn, 1)
@@ -54,7 +54,7 @@ func TestWriteOnAcceptedConnBeforeEstablished(t *testing.T) {
 	}()
 
 	accepted, err := acceptor.Accept()
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer accepted.Close()
 
 	// The acceptor hasn't processed the dialer's data packet yet, so libutp
@@ -75,7 +75,7 @@ func TestWriteOnAcceptedConnBeforeEstablished(t *testing.T) {
 	close(tokens)
 	select {
 	case err := <-written:
-		require.NoError(t, err)
+		qt.Assert(t, qt.IsNil(err))
 	case <-time.After(10 * time.Second):
 		t.Fatal("write didn't complete after the connection was established")
 	}

--- a/bench_test.go
+++ b/bench_test.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/anacrolix/missinggo"
 	"github.com/bradfitz/iter"
-	"github.com/stretchr/testify/require"
+
+	"github.com/go-quicktest/qt"
 )
 
 func benchmarkThroughput(t *testing.B, n int64) {
 	s1, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s1.Close()
 	s2, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s2.Close()
 	var c2 net.Conn
 	accepted := make(chan struct{})
@@ -24,10 +25,10 @@ func benchmarkThroughput(t *testing.B, n int64) {
 		defer close(accepted)
 		var err error
 		c2, err = s2.Accept()
-		require.NoError(t, err)
+		qt.Assert(t, qt.IsNil(err))
 	}()
 	c1, err := s1.Dial(s2.Addr().String())
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer c1.Close()
 	<-accepted
 	defer c2.Close()
@@ -38,12 +39,12 @@ func benchmarkThroughput(t *testing.B, n int64) {
 		go func() {
 			defer close(doneReading)
 			wn, err := io.CopyN(ioutil.Discard, c2, n)
-			require.NoError(t, err)
-			require.EqualValues(t, n, wn)
+			qt.Assert(t, qt.IsNil(err))
+			qt.Assert(t, qt.Equals(wn, n))
 		}()
 		wn, err := io.CopyN(c1, missinggo.ZeroReader, n)
-		require.NoError(t, err)
-		require.EqualValues(t, n, wn)
+		qt.Assert(t, qt.IsNil(err))
+		qt.Assert(t, qt.Equals(wn, n))
 		<-doneReading
 	}
 }

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 
 	"github.com/bradfitz/iter"
-	qt "github.com/frankban/quicktest"
+	"github.com/go-quicktest/qt"
 )
 
 // Test for a race that occurs if the error returned from PacketConn.WriteTo in sendtoCallback holds
 // a reference to the addr passed to the call, and the addr storage is reused between calls to
 // sendtoCallback in this instance.
 func TestSendToRaceErrorAddr(t *testing.T) {
-	c := qt.New(t)
 	s, err := NewSocket("udp", "localhost:0")
-	c.Assert(err, qt.IsNil)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -25,8 +24,8 @@ func TestSendToRaceErrorAddr(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			_, err := s.DialContext(ctx, "udp", "1.1.1.1:1")
-			c.Log(err.Error())
-			c.Assert(err, qt.Not(qt.IsNil))
+			t.Log(err.Error())
+			qt.Assert(t, qt.Not(qt.IsNil(err)))
 		}()
 	}
 	wg.Wait()

--- a/conn_test.go
+++ b/conn_test.go
@@ -4,25 +4,24 @@ import (
 	"net"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/go-quicktest/qt"
 )
 
 func TestConnMethodsAfterClose(t *testing.T) {
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	d, a := connPairSocket(s)
 	// We need to trigger libutp to destroy the Conns, the fastest way to do
 	// this is destroy the parent Socket.
-	assert.NoError(t, s.Close())
+	qt.Check(t, qt.IsNil(s.Close()))
 	for _, c := range []net.Conn{d, a} {
 		// We're trying to test what happens when the Conn isn't known to
 		// libutp anymore.
-		assert.Nil(t, c.(*Conn).us)
+		qt.Check(t, qt.IsNil(c.(*Conn).us))
 		// These functions must not panic. I'm not sure we care what they
 		// return.
-		assert.NotPanics(t, func() { c.RemoteAddr() })
-		assert.NotPanics(t, func() { c.LocalAddr() })
+		qt.Check(t, qt.Not(qt.PanicMatches(func() { c.RemoteAddr() }, ".*")))
+		qt.Check(t, qt.Not(qt.PanicMatches(func() { c.LocalAddr() }, ".*")))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,24 +11,20 @@ require (
 	github.com/anacrolix/sync v0.0.0-20180808010631-44578de4e778
 	github.com/anacrolix/tagflag v1.1.0
 	github.com/bradfitz/iter v0.0.0-20191230175014-e8f45d346db8
-	github.com/frankban/quicktest v1.14.6
-	github.com/stretchr/testify v1.7.0
+	github.com/go-quicktest/qt v1.102.0
 	golang.org/x/net v0.47.0
 )
 
 require (
 	github.com/anacrolix/log v0.13.1 // indirect
 	github.com/anacrolix/missinggo/perf v1.0.0 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,9 +40,10 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
 github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
+github.com/go-quicktest/qt v1.102.0 h1:HSQxCeh5YZH3EL3W39ixjtyaEhcWSXQHtHnMBzSs474=
+github.com/go-quicktest/qt v1.102.0/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -93,7 +94,6 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1N
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/socket_test.go
+++ b/socket_test.go
@@ -3,23 +3,22 @@ package utp
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/go-quicktest/qt"
 )
 
 func TestUseClosedSocket(t *testing.T) {
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
-	assert.NoError(t, s.Close())
-	assert.NotPanics(t, func() { s.Close() })
+	qt.Assert(t, qt.IsNil(err))
+	qt.Check(t, qt.IsNil(s.Close()))
+	qt.Check(t, qt.Not(qt.PanicMatches(func() { s.Close() }, ".*")))
 	c, err := s.Dial(neverResponds)
-	assert.Error(t, err)
-	assert.Nil(t, c)
+	qt.Check(t, qt.IsNotNil(err))
+	qt.Check(t, qt.IsNil(c))
 }
 
 func TestSocketNetwork(t *testing.T) {
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
-	assert.Equal(t, "udp", s.Addr().Network())
+	qt.Check(t, qt.Equals(s.Addr().Network(), "udp"))
 }

--- a/utp_test.go
+++ b/utp_test.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	_ "github.com/anacrolix/envpprof"
-	qt "github.com/frankban/quicktest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/go-quicktest/qt"
 	"golang.org/x/net/nettest"
 )
 
@@ -81,33 +79,33 @@ func TestLibutpDialTimesOut(t *testing.T) {
 		t.SkipNow()
 	}
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	_, err = s.Dial(neverResponds)
-	require.Error(t, err)
+	qt.Assert(t, qt.IsNotNil(err))
 }
 
 // Ensure that our timeout is honored during dialing.
 func TestDialTimeout(t *testing.T) {
 	t.Parallel()
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	const timeout = time.Second
 	started := time.Now()
 	_, err = s.DialTimeout(neverResponds, timeout)
 	timeTaken := time.Since(started)
 	t.Logf("dial returned after %s", timeTaken)
-	assert.Equal(t, context.DeadlineExceeded, err)
-	assert.True(t, timeTaken >= timeout)
+	qt.Check(t, qt.Equals(err, context.DeadlineExceeded))
+	qt.Check(t, qt.IsTrue(timeTaken >= timeout))
 }
 
 func TestConnSendBuffer(t *testing.T) {
 	s0, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s0.Close()
 	s1, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s1.Close()
 	var (
 		c1        net.Conn
@@ -119,15 +117,15 @@ func TestConnSendBuffer(t *testing.T) {
 		c1, acceptErr = s1.Accept()
 	}()
 	c0, err := s0.Dial(s1.Addr().String())
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	<-accepted
-	require.NoError(t, acceptErr)
+	qt.Assert(t, qt.IsNil(acceptErr))
 	defer c0.Close()
 	defer c1.Close()
 	buf := make([]byte, 1024)
 	written := 0
 	for {
-		require.NoError(t, c0.SetWriteDeadline(time.Now().Add(time.Second)))
+		qt.Assert(t, qt.IsNil(c0.SetWriteDeadline(time.Now().Add(time.Second))))
 		n, err := c0.Write(buf)
 		written += n
 		if err != nil {
@@ -141,18 +139,18 @@ func TestConnSendBuffer(t *testing.T) {
 func TestCanHandleConnectWriteErrors(t *testing.T) {
 	t.Parallel()
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	_, err = s.DialContext(context.Background(), "", "localhost:0")
-	require.Error(t, err)
+	qt.Assert(t, qt.IsNotNil(err))
 }
 
 func TestConnectConnAfterSocketClose(t *testing.T) {
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	s.Close()
 	_, err = s.DialContext(context.Background(), "", "")
-	require.Equal(t, errSocketClosed, err)
+	qt.Assert(t, qt.Equals(err, errSocketClosed))
 }
 
 func assertSocketConnsLen(t *testing.T, s *Socket, l int) {
@@ -168,7 +166,7 @@ func assertSocketConnsLen(t *testing.T, s *Socket, l int) {
 
 func TestSocketConnsAfterConnClosed(t *testing.T) {
 	s, err := NewSocket("udp", "localhost:0")
-	require.NoError(t, err)
+	qt.Assert(t, qt.IsNil(err))
 	defer s.Close()
 	c, err := s.DialContext(context.Background(), "", s.LocalAddr().String())
 	t.Logf("connecting to own socket: %v", err)
@@ -188,9 +186,9 @@ func TestSocketConnsAfterConnClosed(t *testing.T) {
 // the maximum. Timestamps come from the runtime's monotonic clock and are never negative, which is
 // what clearing the sign bit of the generated value stands for.
 func TestMaxExpiryTimerMath(t *testing.T) {
-	qt.Check(t, quick.Check(func(u uint64) bool {
+	qt.Check(t, qt.IsNil(quick.Check(func(u uint64) bool {
 		now := int64(u &^ (1 << 63))
 		when := now + math.MaxInt64
 		return when == math.MaxInt64 || when < 0
-	}, nil), qt.IsNil)
+	}, nil)))
 }


### PR DESCRIPTION
The tests currently use **three** assertion styles: frankban's `*qt.C` wrapper, frankban's package-level `qt.Check(t, got, checker)` form, and `stretchr/testify`. This collapses them onto one — [`github.com/go-quicktest/qt`](https://github.com/go-quicktest/qt) (v1.102.0), the successor to `frankban/quicktest`, whose generic checker *functions* are type-checked at compile time ([rationale](https://github.com/go-quicktest/qt#why-a-new-package)).

### Translation applied

| before | after |
| --- | --- |
| `c := qt.New(t)` | *(removed — `t` is used directly)* |
| `c.Assert(err, qt.IsNil)` | `qt.Assert(t, qt.IsNil(err))` |
| `c.Assert(err, qt.Not(qt.IsNil))` | `qt.Assert(t, qt.Not(qt.IsNil(err)))` |
| `qt.Check(t, x, qt.IsNil)` *(package-level v1 form)* | `qt.Check(t, qt.IsNil(x))` |
| `require.NoError(t, err)` | `qt.Assert(t, qt.IsNil(err))` |
| `assert.Equal(t, want, got)` | `qt.Check(t, qt.Equals(got, want))` |
| `assert.NotPanics(t, f)` | `qt.Check(t, qt.Not(qt.PanicMatches(f, ".*")))` |

Note the testify argument order flips: testify takes `(expected, actual)`, qt takes `(got, want)`. `require.*` → `qt.Assert` (fatal), `assert.*` → `qt.Check` (non-fatal), preserving control flow.

### `NotPanics` has no direct equivalent

qt has `PanicMatches` but no `NotPanics`, so the three `assert.NotPanics` sites become `qt.Not(qt.PanicMatches(f, ".*"))`. That is exact rather than approximate: `PanicMatches` fails when `f` doesn't panic, and `.*` matches any panic value, so negating it asserts precisely "`f` does not panic" — and the panic is still recovered rather than crashing the test binary.

If you'd rather just call the function bare (a panic fails the test anyway), that's a one-line change — but keeping the checker preserves the stated intent at the call site.

### Verification

```
go test -gcflags=-e -c -o /dev/null .   # test binary builds clean
go test -count=1 ./...                  # ok github.com/anacrolix/go-libutp  87.3s
gofmt -l .                              # clean
```

Green on `master` first (89.3s), so this is a like-for-like run of the full cgo suite. Both `frankban/quicktest` and `stretchr/testify` drop out of `go.mod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BA3b7BbaJkPeeTYjhvi5g

---
_Generated by [Claude Code](https://claude.ai/code/session_013BA3b7BbaJkPeeTYjhvi5g)_